### PR TITLE
Fix Prisma client generation issue in startup script

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -174,6 +174,15 @@ setup_database() {
 # Run database setup
 setup_database
 
+# Generate Prisma client after database setup
+echo "🔧 Generating Prisma client..."
+if npx prisma generate; then
+  echo "✅ Prisma client generated successfully"
+else
+  echo "❌ Failed to generate Prisma client"
+  exit 1
+fi
+
 # Run post-deploy setup
 echo "⚙️ Running post-deploy setup..."
 if npm run postdeploy; then


### PR DESCRIPTION
- Add prisma generate step after database setup and before post-deploy
- Ensures Prisma client is available for post-deploy scripts and server startup
- Fixes 'Prisma client did not initialize yet' error in production deployment