### PR TITLE
Fix tenant signature email URLs to use www.spectrum4.ca

### DIFF
--- a/server/utils/tenantSignatureService.js
+++ b/server/utils/tenantSignatureService.js
@@ -52,7 +52,7 @@ const sendTenantSignatureRequest = async ({
     const transporter = createTransporter();
     
     // Create signature URL
-    const signatureUrl = `${process.env.BASE_URL || 'https://spectrum4.ca'}/tenant-signature/${submissionId}/${signatureToken}`;
+    const signatureUrl = `${process.env.BASE_URL || 'https://www.spectrum4.ca'}/tenant-signature/${submissionId}/${signatureToken}`;
     
     const emailContent = generateTenantSignatureEmail({
       tenantName,


### PR DESCRIPTION
- Changed BASE_URL fallback from https://spectrum4.ca to https://www.spectrum4.ca
- Resolves 'no available server' error when tenants click signature links in emails
- Ensures email links match the configured domain that responds correctly