### PR TITLE
Fix tenant signature success redirect to use correct domain

### DIFF
--- a/src/pages/TenantSignature.tsx
+++ b/src/pages/TenantSignature.tsx
@@ -129,8 +129,8 @@ const TenantSignature = () => {
         description: "Your signature has been recorded. Thank you for completing Form K.",
       });
 
-      // Redirect to success page
-      navigate('/tenant-signature-success');
+      // Redirect to home page with correct domain
+      window.location.href = 'https://www.spectrum4.ca/';
 
     } catch (error) {
       console.error('Signature submission error:', error);


### PR DESCRIPTION
- Changed redirect from relative path '/tenant-signature-success' to absolute URL 'https://www.spectrum4.ca/'
- Resolves 404 error when users complete signature on spectrum4.ca (without www)
- Ensures users are redirected to the correct domain after successful signature submission