### PR TITLE
Fix PDF attachment generation for Form K completion emails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,20 @@ FROM node:20-alpine AS runner
 
 WORKDIR /app
 
-# Install system dependencies
-RUN apk add --no-cache sqlite
+# Install system dependencies including Puppeteer requirements
+RUN apk add --no-cache \
+    sqlite \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    && rm -rf /var/cache/apk/*
+
+# Tell Puppeteer to use the installed Chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Copy package files for production install
 COPY package*.json ./

--- a/server/utils/formKPdfGenerator.js
+++ b/server/utils/formKPdfGenerator.js
@@ -9,11 +9,19 @@ const generateFormKPdf = async (formData) => {
     // Launch browser in headless mode
     browser = await puppeteer.launch({
       headless: true,
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
-        '--disable-gpu'
+        '--disable-gpu',
+        '--disable-web-security',
+        '--disable-features=VizDisplayCompositor',
+        '--run-all-compositor-stages-before-draw',
+        '--no-first-run',
+        '--no-zygote',
+        '--single-process',
+        '--disable-extensions'
       ]
     });
 


### PR DESCRIPTION
- Add Chromium and required dependencies to Dockerfile for Puppeteer
- Configure Puppeteer to use system Chromium in Alpine Linux
- Add additional Chrome flags for headless operation in Docker
- Resolves missing PDF attachments in Form K completion notifications

Dependencies added:
- chromium (browser engine)
- nss, freetype, harfbuzz (rendering libraries)
- ca-certificates, ttf-freefont (certificates and fonts)

Puppeteer configuration:
- Uses system Chromium via PUPPETEER_EXECUTABLE_PATH
- Added Docker-optimized Chrome flags for stability