### PR TITLE
Fix Form K configuration update API endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -3221,6 +3221,7 @@ app.get('/api/form-configurations/:formName', async (req, res) => {
 // Update form configuration
 app.put('/api/form-configurations/:id', async (req, res) => {
   try {
+    const db = await getPrisma();
     const { id } = req.params;
     const { displayName, description, isActive, emailConfig, recipients } = req.body;
     


### PR DESCRIPTION
- Add missing database connection initialization in PUT /api/form-configurations/:id
- Resolves 500 Internal Server Error when updating form configurations
- Ensures db variable is properly initialized before database operations

Bug: The endpoint was trying to use db.formConfiguration.update() without initializing the database connection via getPrisma()